### PR TITLE
fix: preserve markdown syntax in mention textarea

### DIFF
--- a/apps/web/src/components/mention-textarea.tsx
+++ b/apps/web/src/components/mention-textarea.tsx
@@ -138,7 +138,11 @@ export const MentionTextarea = forwardRef<MentionTextareaRef, MentionTextareaPro
           orderedList: false,
           blockquote: false,
           codeBlock: false,
+          code: false,
           horizontalRule: false,
+          bold: false,
+          italic: false,
+          strike: false,
         }),
         Placeholder.configure({
           placeholder: placeholder || "",


### PR DESCRIPTION
closes #24 